### PR TITLE
do not confuse / after newline with regex

### DIFF
--- a/tmLanguage/JavaScript (JSX).JSON-tmLanguage
+++ b/tmLanguage/JavaScript (JSX).JSON-tmLanguage
@@ -61,7 +61,7 @@
 
 
     "regexp": {
-      "begin": "(?<=[=(:]|^|return|&&|\\|\\||!)\\s*(/)(?![/*+{}?])",
+      "begin": "(?<=[=(:]|^|return|&&|\\|\\||!)\\s*(/)(?![ /*+{}?])",
       "end": "(/)[igm]*",
       "name": "string.regexp.js",
       "endCaptures": {

--- a/tmLanguage/JavaScript (JSX).tmLanguage
+++ b/tmLanguage/JavaScript (JSX).tmLanguage
@@ -1455,7 +1455,7 @@
 		<key>regexp</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;=[=(:]|^|return|&amp;&amp;|\|\||!)\s*(/)(?![/*+{}?])</string>
+			<string>(?&lt;=[=(:]|^|return|&amp;&amp;|\|\||!)\s*(/)(?![ /*+{}?])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
A division operator on a new line caused everything leading up to the next forward slash to be highlighted as a regex. 

``` javascript
render: function() {
  var myRegex = /lol/;   //proper regex, all good
  var bucketWidth = superLongExpressionThatRequiresANewLineBecause80CharsLimit
    / data.buckets.length; /* "fake regex" */
  return (                 /* "fake regex" */
    <div />                /* "fake regex" */
  );
}
```
