### PR TITLE
Add a workaround to support ES6 concise methods

### DIFF
--- a/tmLanguage/JavaScript (JSX).tmLanguage
+++ b/tmLanguage/JavaScript (JSX).tmLanguage
@@ -69,6 +69,10 @@
           <key>include</key>
           <string>#expression</string>
         </dict>
+        <dict>
+          <key>include</key>
+          <string>#method-concise-es6</string>
+        </dict>
       </array>
     </dict>
     <key>block-braces-round</key>
@@ -621,6 +625,59 @@
         <dict>
           <key>include</key>
           <string>#meta-function-body</string>
+        </dict>
+      </array>
+    </dict>
+    <key>method-concise-es6</key>
+    <dict>
+      <key>begin</key>
+      <string>^\s+([a-zA-Z_$]\w*)(\()[^\)]*(\))\s\{$</string>
+      <key>beginCaptures</key>
+      <dict>
+        <key>0</key>
+        <dict>
+          <key>name</key>
+          <string>meta.function.js</string>
+        </dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>entity.name.function.js</string>
+        </dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.parameters.begin.js</string>
+        </dict>
+        <key>3</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.parameters.end.js</string>
+        </dict>
+      </dict>
+      <key>comment</key>
+      <string>attempt to match ES6 concise methods: myFunc(arg) { … }</string>
+      <key>end</key>
+      <string>\}</string>
+      <key>endCaptures</key>
+      <dict>
+        <key>0</key>
+        <dict>
+          <key>name</key>
+          <string>meta.brace.curly.js</string>
+        </dict>
+      </dict>
+      <key>name</key>
+      <string>meta.scope.function.js</string>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>#comment</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#expression</string>
         </dict>
       </array>
     </dict>


### PR DESCRIPTION
ES6 allows a short form of method definition inside an object:

``` javascript
var stuff = {
  someMethod() {
  }
}
```

This commit attempts to support its most common form without introducing false positives.

![](https://camo.githubusercontent.com/850afb9058902968c69a7c2c8e8c3378627850d8/687474703a2f2f692e696d6775722e636f6d2f524d4b504f53752e706e67)
