### PR TITLE
Add JS namespaces to tag name, remove XML namespaces (fixes #7)

### DIFF
--- a/tmLanguage/JavaScript (JSX).tmLanguage
+++ b/tmLanguage/JavaScript (JSX).tmLanguage
@@ -1059,7 +1059,7 @@
     <key>jsx-tag-open</key>
     <dict>
       <key>begin</key>
-      <string>(&lt;)([a-zA-Z0-9:]+)</string>
+      <string>(&lt;)([a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)</string>
       <key>beginCaptures</key>
       <dict>
         <key>1</key>


### PR DESCRIPTION
Except closing issue #7, it seems that there is no reason to leave support of XML namespaces in tag names.

This is result of PR

![screenshot 2014-09-30 18 12 24](https://cloud.githubusercontent.com/assets/234692/4460673/3aabb0ae-48b4-11e4-87b2-7eb0c1faaa36.png)
